### PR TITLE
Make tile entity replacement configurable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,13 +17,15 @@ buildscript {
 
 apply plugin: 'forge'
 
-version = "1.5.5"
+version = "1.5.5-spec"
 group = "ganymedes01.etfuturum"
 archivesBaseName = "Et Futurum"
 
 minecraft {
     version = "1.7.10-10.13.4.1558-1.7.10"
     runDir = "eclipse/assets"
+	replaceIn 'reference.java'
+	replace "@VERSION@", project.version
 }
 
 processResources {

--- a/src/main/java/ganymedes01/etfuturum/EtFuturum.java
+++ b/src/main/java/ganymedes01/etfuturum/EtFuturum.java
@@ -112,6 +112,7 @@ public class EtFuturum {
 	public static boolean enablePlayerSkinOverlay = true;
 	public static boolean enableShearableGolems = true;
 	public static boolean enableShearableCobwebs = true;
+	public static boolean enableTileReplacement = false;
 
 	public static int maxStonesPerCluster = 33;
 

--- a/src/main/java/ganymedes01/etfuturum/configuration/ConfigurationHandler.java
+++ b/src/main/java/ganymedes01/etfuturum/configuration/ConfigurationHandler.java
@@ -93,6 +93,7 @@ public class ConfigurationHandler {
 		EtFuturum.enableShearableGolems = configBoolean("Shearing Snow Golems", true, EtFuturum.enableShearableGolems);
 		EtFuturum.enableShearableCobwebs = configBoolean("Shears harvest cobwebs", true, EtFuturum.enableShearableCobwebs);
 		EtFuturum.enableDragonRespawn = configBoolean("Dragon respawning", true, EtFuturum.enableDragonRespawn);
+		EtFuturum.enableTileReplacement = configBoolean("Replace old Brewing Stands/Enchanting Tables/Daylight SensorS/Beacons with new one on the fly", false, EtFuturum.enableTileReplacement);
 
 		if (configFile.hasChanged())
 			configFile.save();

--- a/src/main/java/ganymedes01/etfuturum/core/proxy/CommonProxy.java
+++ b/src/main/java/ganymedes01/etfuturum/core/proxy/CommonProxy.java
@@ -45,7 +45,9 @@ import net.minecraftforge.common.MinecraftForge;
 public class CommonProxy implements IGuiHandler {
 
 	public void registerEvents() {
-		FMLCommonHandler.instance().bus().register(new WorldTickEventHandler());
+		if (EtFuturum.enableTileReplacement) {
+			FMLCommonHandler.instance().bus().register(new WorldTickEventHandler());
+		}
 		FMLCommonHandler.instance().bus().register(ConfigurationHandler.INSTANCE);
 		FMLCommonHandler.instance().bus().register(ServerEventHandler.INSTANCE);
 		MinecraftForge.EVENT_BUS.register(ServerEventHandler.INSTANCE);

--- a/src/main/java/ganymedes01/etfuturum/lib/Reference.java
+++ b/src/main/java/ganymedes01/etfuturum/lib/Reference.java
@@ -5,7 +5,7 @@ public class Reference {
 	public static final String MOD_ID = "etfuturum";
 	public static final String MOD_NAME = "Et Futurum";
 	public static final String DEPENDENCIES = "required-after:Forge@[10.13.4.1558,);";
-	public static final String VERSION_NUMBER = "1.5.5";
+	public static final String VERSION_NUMBER = "@VERSION@";
 	public static final String ITEM_BLOCK_TEXTURE_PATH = MOD_ID + ":";
 	public static final String ARMOUR_TEXTURE_PATH = ITEM_BLOCK_TEXTURE_PATH + "textures/models/armor/";
 	public static final String ENTITY_TEXTURE_PATH = ITEM_BLOCK_TEXTURE_PATH + "textures/entities/";

--- a/src/main/java/ganymedes01/etfuturum/recipes/ModRecipes.java
+++ b/src/main/java/ganymedes01/etfuturum/recipes/ModRecipes.java
@@ -227,6 +227,37 @@ public class ModRecipes {
 			RecipeSorter.register(Reference.MOD_ID + ".RecipeTippedArrow", RecipeTippedArrow.class, Category.SHAPED, "after:minecraft:shaped");
 			GameRegistry.addRecipe(new RecipeTippedArrow(new ItemStack(ModItems.tipped_arrow), "xxx", "xyx", "xxx", 'x', Items.arrow, 'y', new ItemStack(ModItems.lingering_potion, 1, OreDictionary.WILDCARD_VALUE)));
 		}
+
+		
+		if (EtFuturum.enableBrewingStands) {
+			removeFirstRecipeFor(Blocks.brewing_stand);
+			addShapedRecipe(new ItemStack(ModBlocks.brewing_stand), " i ", "xxx", 'i', Items.blaze_rod, 'x', Blocks.cobblestone);
+			addShapelessRecipe(new ItemStack(ModBlocks.brewing_stand), Blocks.brewing_stand);
+		}
+
+		if(!EtFuturum.enableTileReplacement) { // Add recipes for updated tiles if tile replacement is disabled.
+			if (EtFuturum.enableColourfulBeacons) {
+				removeFirstRecipeFor(Blocks.beacon); // Remove recipe for Minecrafts Beacon
+		        addShapedRecipe(new ItemStack(ModBlocks.beacon), "GGG", "GSG", "OOO", 'G', Blocks.glass, 'S', Items.nether_star, 'O', Blocks.obsidian);
+				addShapelessRecipe(new ItemStack(ModBlocks.beacon), Blocks.beacon); // Minecraft Beacon -> EtFuturum Beacon
+				addShapelessRecipe(new ItemStack(Blocks.beacon), ModBlocks.beacon); // EtFuturm Beacon -> Minecraft Beacon
+			}
+	
+			if (EtFuturum.enableEnchants) {
+				removeFirstRecipeFor(Blocks.enchanting_table); // Remove recipe for Minecrafts Enchanting Table
+		        addShapedRecipe(new ItemStack(ModBlocks.enchantment_table), " B ", "D#D", "###", '#', Blocks.obsidian, 'B', Items.book, 'D', Items.diamond);
+				addShapelessRecipe(new ItemStack(ModBlocks.enchantment_table), Blocks.enchanting_table); // Minecraft Enchanting Table -> EtFuturum Enchanting Table (For any old leftovers)
+				addShapelessRecipe(new ItemStack(Blocks.enchanting_table), ModBlocks.enchantment_table); // EtFuturum Enchanting Table -> Minecraft Enchanting Table (For when you need to to craft something that has it as a component (ChickenChunks))
+			}
+	
+			if (EtFuturum.enableInvertedDaylightSensor) {
+				removeFirstRecipeFor(Blocks.daylight_detector); // Remove recipe for Minecrafts Daylight Sensor
+		        addShapedRecipe(new ItemStack(ModBlocks.daylight_sensor), "GGG", "QQQ", "WWW", 'G', Blocks.glass, 'Q', Items.quartz, 'W', Blocks.wooden_slab);
+				addShapelessRecipe(new ItemStack(ModBlocks.daylight_sensor), Blocks.daylight_detector);
+				addShapelessRecipe(new ItemStack(Blocks.daylight_detector), ModBlocks.daylight_sensor);
+			}
+		}
+
 	}
 
 	private static void addShapedRecipe(ItemStack output, Object... objects) {

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -3,7 +3,7 @@
   "modid": "etfuturum",
   "name": "Et Futurum",
   "description": "A mod dedicated to bring future features to 1.7.10",
-  "version": "1.5.5",
+  "version": "${version}",
   "url": "",
   "updateUrl": "",
   "authorList": [


### PR DESCRIPTION
Made it possible to disable the WorldEventTick that replaces tiles
entites with upgraded versions to make Et Futurum play nice with
Mystcraft.
