### PR TITLE
Banner patterns now black without dye.

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/recipes/RecipeAddPattern.java
+++ b/src/main/java/ganymedes01/etfuturum/recipes/RecipeAddPattern.java
@@ -54,7 +54,7 @@ public class RecipeAddPattern implements IRecipe {
 
 		EnumBannerPattern pattern = getPattern(grid);
 		if (pattern != null) {
-			int dyeMeta = 0;
+			int dyeMeta = 15;
 			ItemStack slot;
 			for (int i = 0; i < grid.getSizeInventory(); i++) {
 				slot = grid.getStackInSlot(i);


### PR DESCRIPTION
dyeMeta 0 is white, when banners should default to black for symbols and patterns.
http://minecraft.gamepedia.com/Banner#Symbols.2FIcons

Small change to fix that inconsistency. Existing banners not affected.
